### PR TITLE
Getting an NPM package's transitive dependencies

### DIFF
--- a/exercises/npm-registry/src/package.ts
+++ b/exercises/npm-registry/src/package.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import got from 'got';
-import { NPMPackage } from './types';
+import { NPMPackage, Dependency } from './types';
+import { versionParser } from  './tools/versions';
 
 /**
  * Attempts to retrieve package data from the npm registry and return it
@@ -9,14 +10,53 @@ export const getPackage: RequestHandler = async function (req, res, next) {
   const { name, version } = req.params;
 
   try {
+    const dependencies = await getPackagesRecursively(name, version);
+    return res.status(200).json({
+      name: name,
+      version: version,
+      dependencies: dependencies,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+
+async function getPackagesRecursively(name, version) {
+/**
+ * The function calls itself recursively until it has reached the "bottom dependency".
+ * At which point, we return the entire dependency branch.
+ * Be careful: each cycle makes a network call
+ * and creates new cycles based on the list of packages found.
+ * @param  {string} name    - Name of the NPM package
+ * @param  {string} version - Desired version of the NPM package
+ * @return {Array.<Dependency>} A list of dependencies
+ */
+  try {
     const npmPackage: NPMPackage = await got(
       `https://registry.npmjs.org/${name}`,
     ).json();
 
     const dependencies = npmPackage.versions[version].dependencies;
+    let formattedDependencies = new Array();
 
-    return res.status(200).json({ name, version, dependencies });
-  } catch (error) {
-    return next(error);
+    if (dependencies !== undefined && Object.keys(dependencies).length > 0) {
+      for (let depName in dependencies) {
+        const depVersion = versionParser(dependencies[depName]),
+         subDependencies = await getPackagesRecursively(depName, depVersion);
+
+        const dependency: Dependency = {
+          name: depName,
+          version: depVersion,
+          dependencies: subDependencies,
+        };
+
+        formattedDependencies.push(dependency);
+      }
+    }
+
+    return formattedDependencies;
+  } catch(error) {
+    return error;
   }
-};
+}

--- a/exercises/npm-registry/src/tools/versions.ts
+++ b/exercises/npm-registry/src/tools/versions.ts
@@ -1,0 +1,12 @@
+export function versionParser(rawVersion) {
+/**
+ NB: this is a very naive implementation and should *not* go into production.
+ * @param  {string} rawVersion - Representation of the version number with its requirements
+ * @return {string} A single version number
+ */
+  return rawVersion
+    .substring(rawVersion.indexOf('^'))
+      .replace('^', '')
+        .replace('~', '')
+          .split(' ')[0];
+}

--- a/exercises/npm-registry/src/types.ts
+++ b/exercises/npm-registry/src/types.ts
@@ -39,3 +39,16 @@ export interface NPMPackage {
     };
   };
 }
+
+
+export interface Dependency {
+/**
+ * An object representing a dependency 
+ * with its attributes names and child dependencies.
+ *
+ * @type {Object.<string, string | Array.<Dependency>}
+ */
+  name: string,
+  version: string,
+  dependencies?: [Dependency],
+}

--- a/exercises/npm-registry/test/package.test.ts
+++ b/exercises/npm-registry/test/package.test.ts
@@ -35,10 +35,38 @@ describe('/package/:name/:version endpoint', () => {
       `http://localhost:${port}/package/${packageName}/${packageVersion}`,
     ).json();
 
-    expect(res.dependencies).toEqual({
-      'loose-envify': '^1.1.0',
-      'object-assign': '^4.1.1',
-      'prop-types': '^15.6.2',
+    expect(res).toEqual({
+      "name": "react",
+      "version": "16.13.0",
+      "dependencies": [{
+        "name": "loose-envify",
+        "version": "1.1.0",
+        "dependencies": [{
+          "name": "js-tokens",
+          "version": "1.0.1",
+          "dependencies": []
+        }]
+      }, {
+        "name": "object-assign",
+        "version": "4.1.1",
+        "dependencies": []
+      }, {
+        "name": "prop-types",
+        "version": "15.6.2",
+        "dependencies": [{
+          "name": "loose-envify",
+          "version": "1.3.1",
+          "dependencies": [{
+            "name": "js-tokens",
+            "version": "3.0.0",
+            "dependencies": []
+          }]
+        }, {
+          "name": "object-assign",
+          "version": "4.1.1",
+          "dependencies": []
+        }]
+      }]
     });
   });
 });


### PR DESCRIPTION
# Getting an NPM package's transitive dependencies

### 🚀  Objective
This is an update to the `/package` endpoint. The endpoint's behaviour on `master` is to return the first level dependencies.
The goal of this change is to also return the list of sub-dependencies for every dependency until we reach the "bottom level" dependencies.

### 🧪  Testing
- The tests run as part of the CI pipeline (🔧 **to do**).
- To run them manually: `npm run test`
- You can also use your browser / Postman by sending a `GET` request to: http://localhost:3000/package/react/16.13.0

**Coverage**
| Function / Type          | Covered     | Notes |
| -------------            | :--------:  | ----- |
| `getPackagesRecursively` | ✅          | 🔧 **To do:** change using fixtures available to avoid including network as part of the test.   |
| `versionParser`          | ❎          | 🔧 **To do:** version parser implemented naively, needs more work.   |
| `Dependency`             | ❎          | N/A   |

### 📃  Documentation
Documentation is available as part of the new function's and types docstrings to facilitate use of JSDoc.
| Function / Type          | Documented  | Notes |
| -------------            | :--------:  | ----- |
| `getPackagesRecursively` | ✅          | N/A   |
| `versionParser`          | ✅          | N/A   |
| `Dependency`             | ✅          | N/A   |


### 💾 Storage
**🔧 To Do**
Given that `getPackagesRecursively` uses both a loop and a recursive call, we have an `O(n^2)` time complexity (quadric time).
Meaning calling the endpoint is expensive - especially since we're making a network call at every cycle. To avoid re-calculating the results every time, a storage solution is recommended.

##### Criteria
- Read heavy.
- Updates performed at regular but scheduled intervals (we'll invalidate a record if it's requested but is older than X hours).
- Data stored is non critical and doesn't contain sensitive elements (user data, GDPR requirements, no need for encryption...).

##### Possible solutions
1. Cache-like tool such as Redis. This will allow us to store records representations as objects and serve them from memory.
2. Static files and CDN. Probably the cheapest option and also very fast. Store the results in simple JSON files served as static assets from a CDN.

##### Improvements
Keep an index of most requested packages in a simple, traditional RDBMS to use for potential cache warm up.


### 🔐 Security
**🔧 To Do**
##### 1. Graph breadth and depth
We don't know in advance how wide and deep the dependency tree is going to be, yet we need to traverse the entire graph to be able to return all transitive dependencies.
This is a significant challenge as we could potentially use up an unlimited amount of resources to reach the bottom nodes (time complexity problem described above).
To prevent that from happening, we could implement:
    **a.** A depth counter for each branch and warn the user when a branch has reached its maximally allowed depth (and stop the recursive calls there).
    **b.** A literal time counter that would stop the execution in case we reach some type of time threshold.

##### 2. API throttle
As it stands, our endpoint allows an unlimited number of calls. This poses a risk of abuse as an attacker or zealous user might overload the service by sending a large amount of `GET` requests in a limited timeframe.
In order to mitigate the issue we could implement:
    **a.** Place a set limit of requests per second / minute / hour... per IP or other traffic attribution method.
    **b.** An API key requirement that would work in conjunction to the API throttle but maybe offer higher quotas.

### 👀 Visualization
The results are presented as a dependency tree (represented as JSON) with currently no limit as to how deep the branches can go.
We have a top level object (the initially requested dependency). Each node contains the dependency's data, including an array containing the child dependencies of that node.
```json
{
  "name": "a",
  "version": "1.0",
  "dependencies": [{
    "name": "b",
    "version": "1.0",
    "dependencies": [{
        "name": "c",
        "version": "1.0",
        "dependencies": [{
          "name": "d",
          "version": "1.0",
          "dependencies": []
        }]
      },
      {
        "name": "e",
        "version": "1.0",
        "dependencies": []
      },
      {
        "name": "f",
        "version": "1.0",
        "dependencies": []
      }
    ]
  }]
}
```
